### PR TITLE
Pin torchvision & torchaudio to torch 2.6.0

### DIFF
--- a/requirements/requirements-torch.txt
+++ b/requirements/requirements-torch.txt
@@ -12,8 +12,8 @@ requests
 scipy
 sentencepiece
 tokenizers==0.20.1
-torchaudio
-torchvision
+torchaudio==2.6.0
+torchvision==0.21.0
 wandb
 boto3
 arrow


### PR DESCRIPTION
`requirements/requirements.txt` locks `torch==2.6.0` but `requirements/requirements-torch.txt` leaves `torchaudio` and `torchvision` unpinned. `make setup-env` gets to `requirements/requirements-torch.txt` *after* it gets to `requirements/requirements.txt`, meaning that `pip` upgrades to the latest PyTorch, 2.7.0.

This causes issues for Flash Attention. Since `flash-attn` is listed *before* `torchaudio` and `torchvision` in `requirements/requirements-torch.txt`, it's built for PyTorch 2.6.0. This mismatched build causes undefined symbol errors at runtime.

The simplest fix is to pin `torchvision` and `torchaudio` to PyTorch 2.6.0. (I checked with a `pipdeptree` that these are the only dependencies forcing the upgrade to `torch 2.7.0` during `make setup-env`.) In this PR, I've taken their corresponding versions from the [PyTorch previous versions page](https://pytorch.org/get-started/previous-versions/).

The other "fix", which is just living with PyTorch 2.7.0, is a bad idea at least for now, because Flash Attention doesn't ship binary wheels for PyTorch 2.7.0, requiring a [slow](https://twitter.com/spikedoanz/status/1922840487636914538) compile from source.