### PR TITLE
Fixes to get Savanna working for Evo2 fine-tuning, as of July 2025

### DIFF
--- a/requirements/requirements-torch.txt
+++ b/requirements/requirements-torch.txt
@@ -20,6 +20,7 @@ arrow
 ring_flash_attn
 pydantic<=2.8.2
 numpy<=2.2.6 # to enable the binary mode of np.fromstring
+transformer-engine==1.13.0
 
 # Git repositories
 # git+https://github.com/NVIDIA/TransformerEngine.git@stable

--- a/requirements/requirements-torch.txt
+++ b/requirements/requirements-torch.txt
@@ -2,7 +2,7 @@ PyYAML
 causal-conv1d
 deepspeed
 einops
-flash-attn
+flash-attn<=2.7.4
 lazy_import_plus
 omegaconf
 opt-einsum
@@ -11,13 +11,15 @@ regex
 requests
 scipy
 sentencepiece
-tokenizers==0.20.1
-torchaudio
-torchvision
+tokenizers>=0.20.1
+torchaudio==2.6.0
+torchvision==0.21.0
 wandb
 boto3
 arrow
 ring_flash_attn
+pydantic<=2.8.2
+numpy<=2.2.6 # to enable the binary mode of np.fromstring
 
 # Git repositories
 # git+https://github.com/NVIDIA/TransformerEngine.git@stable

--- a/requirements/requirements-torch.txt
+++ b/requirements/requirements-torch.txt
@@ -2,7 +2,7 @@ PyYAML
 causal-conv1d
 deepspeed
 einops
-flash-attn<=2.7.4
+flash-attn>=2.1.1,<=2.6.3
 lazy_import_plus
 omegaconf
 opt-einsum

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,1 +1,4 @@
 torch==2.6.0
+
+ftfy
+lm_dataformat

--- a/savanna/data/indexed_dataset.py
+++ b/savanna/data/indexed_dataset.py
@@ -465,7 +465,7 @@ class MMapIndexedDataset(torch.utils.data.Dataset):
         return self._path
 
     def __setstate__(self, state):
-        self._do_init(state)
+        self._do_init(state, True)
 
     def _do_init(self, path, skip_warmup):
         self._path = path


### PR DESCRIPTION
This PR resolves two classes of issues I faced when fine-tuning Evo2 on a single instance in June/July 2025:
- Package versioning issues:
  - PyTorch was pinned to 2.6.0, but the corresponding versions of torchvision and torchaudio weren't pinned. Since a newer version of PyTorch is now available, incompatible versions of torchvision and torchaudio were being installed.
  - In the latest version of Numpy, the binary mode of `np.fromstring` is fully deprecated. With this version of Numpy, in the `tokenize` method of the `CharLevelTokenizer` class, the line `return list(np.fromstring(text, dtype=np.uint8))` raises the error: `ValueError: The binary mode of fromstring is removed, use frombuffer instead` when the user runs `tools/preprocess_data.py` with the argument `--tokenizer-type CharLevelTokenizer`. Thus, I pinned the numpy version to the last version before this deprecation.
  - With any available version of `transformer-engine` in the 2.x series, I was encountering [this issue](https://github.com/NVIDIA/TransformerEngine/issues/1585). Thus, I pinned `transformer-engine` to version 1.13.0.
  - The latest version of `flash-attn` wasn't compatible with some other package versions, so it was raising a warning when I fine-tuned. I pinned it to a compatible version.
- Small bugs:
  - The `__setstate__` method of the `MMapIndexedDataset` class (in `savanna/data/indexed_dataset.py`) calls the class's `_do_init` method with one argument. But the `_do_init` argument requires two arguments, so the code was erroring when calling this method. Thus, I added the value of `True` for the `skip_warmup` argument.