### PR TITLE
feat: add LoRA (Low-Rank Adaptation) for parameter-efficient finetuning

### DIFF
--- a/savanna/arguments/arguments.py
+++ b/savanna/arguments/arguments.py
@@ -37,6 +37,7 @@ from .global_config import (
     GlobalConfigTraining,
     operator_type_CHOICES,
 )
+from .lora_config import GlobalConfigLoRA
 
 ZERO_DEFAULTS = {
     "stage": 0,
@@ -82,6 +83,7 @@ BASE_CLASSES = [
     GlobalConfigTextgen,
     GlobalConfigOther,
     GlobalConfigProfiler,
+    GlobalConfigLoRA,
 ]
 
 DEEPSPEED_ARG_CLASSES = [GlobalConfigDeepspeedRunner, GlobalConfigDeepspeedConfig]

--- a/savanna/arguments/lora_config.py
+++ b/savanna/arguments/lora_config.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+
+try:
+    from .template import GlobalConfigTemplate
+except ImportError:
+    from template import GlobalConfigTemplate
+
+
+@dataclass
+class GlobalConfigLoRA(GlobalConfigTemplate):
+
+    lora: dict = None
+    """
+    LoRA configuration dict. Keys:
+      'enabled': bool (default False) — whether LoRA is active
+      'r': int (default 8) — rank
+      'alpha': float (default 16.0) — scaling factor (scaling = alpha / r)
+      'dropout': float (default 0.0)
+      'target_modules': list[str] — leaf module name patterns to wrap,
+          e.g. ["dense_projection", "dense", "w1", "w2", "w3"]
+      'freeze_base_model': bool (default True) — freeze all non-LoRA params
+      'modules_to_save': list[str] or None — additional module name patterns
+          to keep trainable (e.g. ["layernorm"])
+      'save_merged': bool (default False) — merge LoRA into base weights on save
+      'lora_lr': float or None — separate LR for LoRA params
+      'lora_weight_decay': float (default 0.0) — weight decay for LoRA params
+    """
+
+    def __post_init__(self):
+        if self.lora is not None and self.lora.get("enabled", False):
+            r = self.lora.get("r", 8)
+            if not isinstance(r, int) or r < 1:
+                raise ValueError(f"LoRA 'r' must be a positive integer, got {r!r}")
+
+            alpha = self.lora.get("alpha", 16.0)
+            if not isinstance(alpha, (int, float)) or alpha <= 0:
+                raise ValueError(f"LoRA 'alpha' must be a positive number, got {alpha!r}")
+
+            dropout = self.lora.get("dropout", 0.0)
+            if not isinstance(dropout, (int, float)) or not (0.0 <= dropout < 1.0):
+                raise ValueError(f"LoRA 'dropout' must be a float in [0, 1), got {dropout!r}")
+
+            target_modules = self.lora.get("target_modules", [])
+            if not isinstance(target_modules, list):
+                raise ValueError(
+                    f"LoRA 'target_modules' must be a list of strings, got {type(target_modules).__name__}"
+                )

--- a/savanna/checkpointing.py
+++ b/savanna/checkpointing.py
@@ -326,14 +326,26 @@ def save_ds_checkpoint(iteration, model, global_config):
     # checkpoint folder name
     tag = f"global_step{iteration}"
 
+    # LoRA: merge weights into base if save_merged is True
+    lora_cfg = getattr(global_config, "lora", None)
+    lora_enabled = lora_cfg is not None and lora_cfg.get("enabled", False)
+    save_merged = lora_enabled and lora_cfg.get("save_merged", False)
+    if save_merged:
+        from savanna.lora import merge_lora_weights, unmerge_lora_weights
+
+        merge_lora_weights(model)
+
     # save checkpoint
-    if global_config.async_save:
+    # When save_merged is True, force a blocking save to avoid a race condition:
+    # async save may still be reading model memory when we unmerge weights below.
+    use_async = global_config.async_save and not save_merged
+    if save_merged and global_config.async_save:
+        print_rank_0("LoRA: save_merged=True forces blocking save (async_save disabled for this checkpoint).")
+    if use_async:
         # print(f"SAVE_CHECKPOINT: USING ASYNC SAVE")
-        ret = model.save_checkpoint(
-            global_config.save, tag=tag, client_state=sd, async_save=global_config.async_save
-        )
+        ret = model.save_checkpoint(global_config.save, tag=tag, client_state=sd, async_save=True)
         global _checkpoint_engine
-        if global_config.async_save and _checkpoint_engine is None:
+        if _checkpoint_engine is None:
             _checkpoint_engine = ret
         if global_config.iteration % global_config.save_retain_interval == 0:
             global retain_on
@@ -345,12 +357,27 @@ def save_ds_checkpoint(iteration, model, global_config):
                 process = mp.Process(target=upload_checkpoint, args=(global_config, global_config.save, tag))
                 process.start()
 
+    # LoRA: unmerge after save if we merged, or save separate LoRA weights
+    if save_merged:
+        unmerge_lora_weights(model)
+    elif lora_enabled:
+        from savanna.lora import get_lora_state_dict
+
+        lora_sd = get_lora_state_dict(model)
+        if lora_sd:
+            save_dir = os.path.join(global_config.save, tag)
+            os.makedirs(save_dir, exist_ok=True)
+            rank = mpu.get_model_parallel_rank()
+            lora_path = os.path.join(save_dir, f"lora_mp_rank_{rank:02d}.pt")
+            torch.save(lora_sd, lora_path)
+            print_rank_0(f"LoRA: saved {len(lora_sd)} params to {lora_path}")
+
     # save config files
     if torch.distributed.get_rank() == 0 and global_config.config_files is not None:
         configs_directory = os.path.join(global_config.save, tag, "configs")
         os.makedirs(configs_directory, exist_ok=True)
         for config_filename, config_data in global_config.config_files.items():
-            with open(os.path.join(configs_directory, config_filename), "w") as f:
+            with open(os.path.join(configs_directory, config_filename), "w", encoding="utf-8") as f:
                 if isinstance(config_data, str):
                     f.write(config_data)
                 else:
@@ -386,6 +413,80 @@ def save_checkpoint(global_config, iteration, model, optimizer, lr_scheduler):
     torch.distributed.barrier()
 
 
+def _make_lora_custom_load_fn(dst_module, strict):
+    """Create a custom load function that remaps base-model checkpoint keys
+    to match the LoRA-wrapped model structure.
+
+    When LoRA wraps a module ``X``, its weight moves from ``X.weight`` to
+    ``X.base_layer.weight``.  A base-model checkpoint still has the old key
+    names, so a naive ``load_state_dict`` with ``strict=False`` silently
+    skips them, leaving the wrapped layers with random weights.
+
+    This function builds a key mapping from the destination model and remaps
+    the source state dict before loading.
+    """
+    from savanna.lora import LoRAColumnParallelLinear, LoRARowParallelLinear, LoRATELinear
+
+    lora_classes = (LoRAColumnParallelLinear, LoRARowParallelLinear, LoRATELinear)
+
+    # Build set of LoRA-wrapped module prefixes (relative to dst_module)
+    lora_prefixes = set()
+    for name, mod in dst_module.named_modules():
+        if isinstance(mod, lora_classes):
+            lora_prefixes.add(name + ".")
+
+    def custom_load_fn(src, dst):
+        if not lora_prefixes:
+            dst.load_state_dict(src, strict=strict)
+            return
+
+        remapped = {}
+        remap_count = 0
+        for key, value in src.items():
+            new_key = key
+            for prefix in lora_prefixes:
+                if key.startswith(prefix) and ".base_layer." not in key:
+                    # Insert "base_layer." after the LoRA module prefix
+                    suffix = key[len(prefix):]
+                    new_key = prefix + "base_layer." + suffix
+                    remap_count += 1
+                    break
+            remapped[new_key] = value
+
+        if remap_count > 0:
+            print_rank_0(f"LoRA checkpoint load: remapped {remap_count} keys to base_layer.*")
+
+        # Handle size mismatches (e.g. pad_mlp_weights padding, seq_length
+        # changes for Hyena filters) by manually copying with padding/truncation
+        # before calling load_state_dict, which would otherwise raise.
+        dst_sd = dst.state_dict()
+        size_mismatch_keys = []
+        for key in list(remapped.keys()):
+            if key in dst_sd and isinstance(remapped[key], torch.Tensor) and remapped[key].shape != dst_sd[key].shape:
+                src_tensor = remapped.pop(key)
+                dst_tensor = dst_sd[key]
+                # Copy overlapping region (handles both padding and truncation)
+                slices = tuple(slice(0, min(s, d)) for s, d in zip(src_tensor.shape, dst_tensor.shape))
+                dst_tensor.zero_()
+                dst_tensor[slices].copy_(src_tensor[slices])
+                size_mismatch_keys.append(key)
+        if size_mismatch_keys:
+            print_rank_0(
+                f"LoRA checkpoint load: handled {len(size_mismatch_keys)} size-mismatched keys "
+                f"via padded/truncated copy (first 5: {size_mismatch_keys[:5]})"
+            )
+
+        missing, unexpected = dst.load_state_dict(remapped, strict=False)
+        # LoRA params (lora_A, lora_B) will be "missing" from a base checkpoint — that's expected
+        lora_missing = [k for k in missing if "lora_" not in k and k not in size_mismatch_keys]
+        if lora_missing:
+            print_rank_0(f"WARNING: {len(lora_missing)} non-LoRA keys missing after remapped load: {lora_missing[:10]}")
+        if unexpected:
+            print_rank_0(f"WARNING: {len(unexpected)} unexpected keys in checkpoint: {unexpected[:10]}")
+
+    return custom_load_fn
+
+
 def load_checkpoint(global_config, model, optimizer, lr_scheduler, inference=False, iteration=None):
     """Load a model checkpoint and return the iteration."""
     iteration = global_config.iteration if iteration is None else iteration
@@ -408,9 +509,20 @@ def load_checkpoint(global_config, model, optimizer, lr_scheduler, inference=Fal
                 print(f"rank{rank} - LOAD_CHECKPOINT: Loading checkpoint with tag {tag}")
         else:
             tag = None
-            
+
         if rank == 0:
             print(f"rank{rank} - LOAD_CHECKPOINT: Loading checkpoint from {global_config.load} with tag {tag}, warmstart={global_config.warmstart}")
+
+        # When finetuning a base checkpoint into a LoRA model, the checkpoint
+        # keys won't have 'base_layer.' but the model expects them.  Use a
+        # custom load function to remap keys.
+        lora_cfg = getattr(global_config, "lora", None)
+        lora_enabled = lora_cfg is not None and lora_cfg.get("enabled", False)
+        custom_load_fn = None
+        if lora_enabled and global_config.finetune:
+            custom_load_fn = _make_lora_custom_load_fn(
+                model.module, strict=global_config.checkpoint_strict_load
+            )
 
         checkpoint_name, state_dict = model.load_checkpoint(
             global_config.load,
@@ -419,6 +531,7 @@ def load_checkpoint(global_config, model, optimizer, lr_scheduler, inference=Fal
             load_module_only=not load_optim_and_scheduler,
             tag=tag,
             load_module_strict=global_config.checkpoint_strict_load,
+            custom_load_fn=custom_load_fn,
         )
 
         if checkpoint_name is None:
@@ -509,6 +622,25 @@ def load_checkpoint(global_config, model, optimizer, lr_scheduler, inference=Fal
                 "exiting ...".format(checkpoint_name)
             )
             sys.exit()
+
+    # LoRA: load separate LoRA weights if present
+    lora_cfg = getattr(global_config, "lora", None)
+    if lora_cfg is not None and lora_cfg.get("enabled", False) and not lora_cfg.get("save_merged", False):
+        rank = mpu.get_model_parallel_rank()
+        # Determine the checkpoint directory for this tag
+        if tag is not None:
+            lora_path = os.path.join(global_config.load, tag, f"lora_mp_rank_{rank:02d}.pt")
+        else:
+            lora_path = None
+
+        if lora_path is not None and os.path.exists(lora_path):
+            from savanna.lora import load_lora_state_dict
+
+            lora_sd = torch.load(lora_path, map_location="cpu", weights_only=True)
+            load_lora_state_dict(model, lora_sd)
+            print_rank_0(f"LoRA: loaded {len(lora_sd)} params from {lora_path}")
+        else:
+            print_rank_0("LoRA: no saved LoRA weights found, starting with zero-initialized B (no-op).")
 
     torch.distributed.barrier()
     if mpu.get_data_parallel_rank() == 0:

--- a/savanna/lora.py
+++ b/savanna/lora.py
@@ -1,0 +1,364 @@
+"""LoRA (Low-Rank Adaptation) implementation for Savanna's parallel linear layers.
+
+Supports ColumnParallelLinear, RowParallelLinear, and TELinear (TransformerEngine)
+with correct tensor-parallel communication patterns.
+"""
+
+import logging
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from savanna import print_rank_0
+from savanna.mpu.mappings import (
+    gather_from_sequence_parallel_region,
+    reduce_from_model_parallel_region,
+    reduce_scatter_to_sequence_parallel_region,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LoRAColumnParallelLinear(nn.Module):
+    """LoRA wrapper for ColumnParallelLinear.
+
+    lora_A: [r, input_size] — full (not partitioned), receives full input
+    lora_B: [output_size_per_partition, r] — partitioned on dim 0, like base weight
+    """
+
+    def __init__(self, base_layer, r, alpha, dropout=0.0):
+        super().__init__()
+        self.base_layer = base_layer
+        self.r = r
+        self.alpha = alpha
+        self.scaling = alpha / r
+
+        input_size = base_layer.input_size
+        output_size_per_partition = base_layer.output_size_per_partition
+        self.sequence_parallel = getattr(base_layer, "sequence_parallel", False)
+        self.seq_dim = getattr(base_layer, "seq_dim", 0)
+
+        device = base_layer.weight.device
+        dtype = base_layer.weight.dtype
+
+        self.lora_A = nn.Parameter(torch.empty(r, input_size, device=device, dtype=dtype))
+        self.lora_B = nn.Parameter(torch.zeros(output_size_per_partition, r, device=device, dtype=dtype))
+
+        nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+
+        self.lora_A._is_lora_param = True
+        self.lora_B._is_lora_param = True
+
+        self.lora_dropout = nn.Dropout(dropout) if dropout > 0.0 else nn.Identity()
+
+    def forward(self, input_):
+        base_output, base_bias = self.base_layer(input_)
+
+        # LoRA path: mirror the base layer's input gathering for sequence parallelism
+        if self.sequence_parallel:
+            lora_input = gather_from_sequence_parallel_region(input_, seq_dim=self.seq_dim)
+        else:
+            lora_input = input_
+
+        lora_out = F.linear(F.linear(self.lora_dropout(lora_input), self.lora_A), self.lora_B) * self.scaling
+        return base_output + lora_out, base_bias
+
+
+class LoRARowParallelLinear(nn.Module):
+    """LoRA wrapper for RowParallelLinear.
+
+    lora_A: [r, input_size_per_partition] — partitioned on dim 1, like base weight
+    lora_B: [output_size, r] — full (not partitioned), produces full output
+    """
+
+    def __init__(self, base_layer, r, alpha, dropout=0.0):
+        super().__init__()
+        self.base_layer = base_layer
+        self.r = r
+        self.alpha = alpha
+        self.scaling = alpha / r
+
+        input_size_per_partition = base_layer.input_size_per_partition
+        output_size = base_layer.output_size
+        self.sequence_parallel = getattr(base_layer, "sequence_parallel", False)
+        self.parallel_output = getattr(base_layer, "parallel_output", False)
+        self.seq_dim = getattr(base_layer, "seq_dim", 0)
+
+        if self.parallel_output and input_size_per_partition != base_layer.input_size:
+            logger.warning(
+                "LoRARowParallelLinear with parallel_output=True and TP > 1: "
+                "the LoRA delta skips the all-reduce but applies full lora_B, "
+                "which is mathematically incorrect. Use parallel_output=False."
+            )
+
+        device = base_layer.weight.device
+        dtype = base_layer.weight.dtype
+
+        self.lora_A = nn.Parameter(torch.empty(r, input_size_per_partition, device=device, dtype=dtype))
+        self.lora_B = nn.Parameter(torch.zeros(output_size, r, device=device, dtype=dtype))
+
+        nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+
+        self.lora_A._is_lora_param = True
+        self.lora_B._is_lora_param = True
+
+        self.lora_dropout = nn.Dropout(dropout) if dropout > 0.0 else nn.Identity()
+
+    def forward(self, input_):
+        base_output, base_bias = self.base_layer(input_)
+
+        # LoRA path: input_ is already partitioned across TP ranks (same as base)
+        if self.base_layer.input_is_parallel:
+            input_parallel = input_
+        else:
+            # Base layer scatters internally; we need the partitioned version
+            from savanna.mpu.mappings import scatter_to_model_parallel_region
+
+            input_parallel = scatter_to_model_parallel_region(input_)
+
+        # lora_A produces partial sum of shape [..., r]
+        lora_intermediate = F.linear(self.lora_dropout(input_parallel), self.lora_A)
+
+        # Reduce across TP ranks (matching base layer's communication pattern)
+        if self.sequence_parallel and not self.parallel_output:
+            lora_intermediate = reduce_scatter_to_sequence_parallel_region(
+                lora_intermediate, seq_dim=self.seq_dim
+            )
+        elif not self.parallel_output:
+            lora_intermediate = reduce_from_model_parallel_region(lora_intermediate)
+
+        lora_out = F.linear(lora_intermediate, self.lora_B) * self.scaling
+        return base_output + lora_out, base_bias
+
+
+class LoRATELinear(nn.Module):
+    """LoRA wrapper for TELinear (TransformerEngine).
+
+    Determines column vs row parallelism from the TELinear subclass type,
+    then applies LoRA delta in compute dtype on top of FP8 base output.
+    """
+
+    def __init__(self, base_layer, r, alpha, dropout=0.0, parallel_mode=None):
+        super().__init__()
+        self.base_layer = base_layer
+        self.r = r
+        self.alpha = alpha
+        self.scaling = alpha / r
+        self.parallel_mode = parallel_mode
+
+        config = base_layer.config
+        self.sequence_parallel = getattr(config, "sequence_parallel", False)
+
+        in_features = base_layer.in_features
+        out_features = base_layer.out_features
+
+        self.seq_dim = getattr(config, "seq_dim", 0)
+
+        # Determine LoRA shapes based on parallel mode
+        if parallel_mode == "column":
+            # Like ColumnParallelLinear: A is full input, B is partitioned output
+            lora_a_size = in_features
+            lora_b_size = out_features  # already partitioned by TE
+        elif parallel_mode == "row":
+            # Like RowParallelLinear: A is partitioned input, B is full output
+            lora_a_size = in_features  # already partitioned by TE
+            lora_b_size = out_features
+        else:
+            raise ValueError(f"Cannot determine parallel_mode for TELinear: {parallel_mode}")
+
+        # Use bf16 for LoRA params (compute dtype) regardless of FP8 base
+        dtype = torch.bfloat16
+        device = next(base_layer.parameters()).device
+
+        self.lora_A = nn.Parameter(torch.empty(r, lora_a_size, device=device, dtype=dtype))
+        self.lora_B = nn.Parameter(torch.zeros(lora_b_size, r, device=device, dtype=dtype))
+
+        nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+
+        self.lora_A._is_lora_param = True
+        self.lora_B._is_lora_param = True
+
+        self.lora_dropout = nn.Dropout(dropout) if dropout > 0.0 else nn.Identity()
+
+    def forward(self, input_):
+        base_output, base_bias = self.base_layer(input_)
+
+        lora_input = input_.to(self.lora_A.dtype)
+
+        if self.parallel_mode == "column":
+            # Column: TE handles sequence parallel gather internally
+            # but we need to do it for our LoRA path
+            if self.sequence_parallel:
+                lora_input = gather_from_sequence_parallel_region(lora_input, seq_dim=self.seq_dim)
+            lora_out = (
+                F.linear(F.linear(self.lora_dropout(lora_input), self.lora_A), self.lora_B) * self.scaling
+            )
+        elif self.parallel_mode == "row":
+            # Row: input is already partitioned, reduce after A
+            lora_intermediate = F.linear(self.lora_dropout(lora_input), self.lora_A)
+            if self.sequence_parallel:
+                lora_intermediate = reduce_scatter_to_sequence_parallel_region(
+                    lora_intermediate, seq_dim=self.seq_dim
+                )
+            else:
+                lora_intermediate = reduce_from_model_parallel_region(lora_intermediate)
+            lora_out = F.linear(lora_intermediate, self.lora_B) * self.scaling
+
+        return base_output + lora_out.to(base_output.dtype), base_bias
+
+
+def _get_parent_and_attr(model, dotted_name):
+    """Split 'a.b.c' into (model.a.b, 'c') for setattr replacement."""
+    parts = dotted_name.rsplit(".", 1)
+    if len(parts) == 1:
+        return model, parts[0]
+    parent_name, attr_name = parts
+    parent = model
+    for p in parent_name.split("."):
+        parent = getattr(parent, p)
+    return parent, attr_name
+
+
+def _detect_te_parallel_mode(module):
+    """Detect whether a TELinear is column or row parallel."""
+    try:
+        from savanna.model.tengine import TEColumnParallelLinear, TERowParallelLinear
+
+        if isinstance(module, TEColumnParallelLinear):
+            return "column"
+        if isinstance(module, TERowParallelLinear):
+            return "row"
+    except ImportError:
+        pass
+
+    # Fallback: check parallel_mode attribute (set by TE's Linear.__init__)
+    parallel_mode = getattr(module, "parallel_mode", None)
+    if parallel_mode in ("column", "row"):
+        return parallel_mode
+
+    return None
+
+
+def apply_lora_to_model(model, global_config):
+    """Apply LoRA adapters to target modules in the model.
+
+    Walks model.named_modules(), matches leaf names against target_modules list,
+    and wraps matching layers with the appropriate LoRA class.
+    """
+    from savanna.mpu.layers import ColumnParallelLinear, RowParallelLinear
+
+    lora_cfg = global_config.lora
+    r = lora_cfg.get("r", 8)
+    alpha = lora_cfg.get("alpha", 16.0)
+    dropout = lora_cfg.get("dropout", 0.0)
+    target_modules = lora_cfg.get("target_modules", [])
+
+    if not target_modules:
+        logger.warning("LoRA enabled but target_modules is empty — no modules will be wrapped.")
+        return
+
+    # Try to import TE classes (may not be available)
+    te_linear_cls = None
+    try:
+        from savanna.model.tengine import TELinear
+
+        te_linear_cls = TELinear
+    except ImportError:
+        pass
+
+    wrapped_count = 0
+    wrapped_names = []
+
+    # Collect all (name, module) pairs first to avoid modification during iteration
+    named_modules = list(model.named_modules())
+
+    for name, module in named_modules:
+        # Check if the leaf name matches any target pattern
+        leaf_name = name.rsplit(".", 1)[-1] if "." in name else name
+        if leaf_name not in target_modules:
+            continue
+
+        parent, attr_name = _get_parent_and_attr(model, name)
+
+        if isinstance(module, ColumnParallelLinear):
+            lora_module = LoRAColumnParallelLinear(module, r=r, alpha=alpha, dropout=dropout)
+            setattr(parent, attr_name, lora_module)
+            wrapped_count += 1
+            wrapped_names.append(name)
+
+        elif isinstance(module, RowParallelLinear):
+            lora_module = LoRARowParallelLinear(module, r=r, alpha=alpha, dropout=dropout)
+            setattr(parent, attr_name, lora_module)
+            wrapped_count += 1
+            wrapped_names.append(name)
+
+        elif te_linear_cls is not None and isinstance(module, te_linear_cls):
+            parallel_mode = _detect_te_parallel_mode(module)
+            if parallel_mode is None:
+                logger.warning(f"Skipping TELinear '{name}': cannot determine parallel_mode.")
+                continue
+            lora_module = LoRATELinear(
+                module, r=r, alpha=alpha, dropout=dropout, parallel_mode=parallel_mode
+            )
+            setattr(parent, attr_name, lora_module)
+            wrapped_count += 1
+            wrapped_names.append(name)
+
+        else:
+            logger.debug(f"Target module '{name}' matched but is type {type(module).__name__}, skipping.")
+
+    if wrapped_count == 0:
+        logger.warning(
+            f"LoRA target_modules={target_modules} matched zero modules. "
+            "Check that target names match leaf module names in the model."
+        )
+    else:
+        print_rank_0(f"LoRA: wrapped {wrapped_count} modules: {wrapped_names}")
+
+
+def get_lora_state_dict(model):
+    """Extract only LoRA parameters from the model state dict."""
+    return {k: v.clone() for k, v in model.state_dict().items() if "lora_A" in k or "lora_B" in k}
+
+
+def load_lora_state_dict(model, state_dict):
+    """Load LoRA-only state dict into model (non-strict)."""
+    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    # Filter out non-LoRA missing keys (expected since we only load LoRA params)
+    lora_missing = [k for k in missing if "lora_A" in k or "lora_B" in k]
+    if lora_missing:
+        logger.warning(f"Missing LoRA keys when loading: {lora_missing}")
+    if unexpected:
+        logger.warning(f"Unexpected keys when loading LoRA state dict: {unexpected}")
+
+
+def merge_lora_weights(model):
+    """Merge LoRA weights into base layer weights for inference/merged checkpointing.
+
+    After merging, the LoRA delta (B @ A * scaling) is added to base_layer.weight,
+    and a flag is set to avoid double-merging.  The original weight is saved so that
+    unmerge can restore it exactly (avoiding bf16 precision loss from subtract).
+    """
+    for name, module in model.named_modules():
+        if isinstance(module, (LoRAColumnParallelLinear, LoRARowParallelLinear, LoRATELinear)):
+            if getattr(module, "_lora_merged", False):
+                continue
+            with torch.no_grad():
+                module._original_weight = module.base_layer.weight.data.clone()
+                delta = (module.lora_B @ module.lora_A) * module.scaling
+                module.base_layer.weight.data += delta.to(module.base_layer.weight.dtype)
+            module._lora_merged = True
+
+
+def unmerge_lora_weights(model):
+    """Reverse the merge operation by restoring the saved original weight."""
+    for name, module in model.named_modules():
+        if isinstance(module, (LoRAColumnParallelLinear, LoRARowParallelLinear, LoRATELinear)):
+            if not getattr(module, "_lora_merged", False):
+                continue
+            with torch.no_grad():
+                module.base_layer.weight.data.copy_(module._original_weight)
+                del module._original_weight
+            module._lora_merged = False

--- a/savanna/model/utils.py
+++ b/savanna/model/utils.py
@@ -102,11 +102,31 @@ def get_params_for_weight_decay_optimization(module, global_config):
         # only return a single param group
         # with onebitadam, we want to minimize the calls to compressed_allreduce. Every param group calls it once.
         # to avoid this, only use a single param group when weight decay is off.
-        return [no_weight_decay_params]
+        param_groups = [no_weight_decay_params]
     elif medium_hyena_params is not None:
-        return weight_decay_params, no_weight_decay_params, medium_hyena_params
+        param_groups = [weight_decay_params, no_weight_decay_params, medium_hyena_params]
+    else:
+        param_groups = [weight_decay_params, no_weight_decay_params]
 
-    return weight_decay_params, no_weight_decay_params
+    # If LoRA is enabled with a separate LR, extract LoRA params into their own group
+    lora_cfg = getattr(global_config, "lora", None)
+    if lora_cfg is not None and lora_cfg.get("enabled", False):
+        lora_lr = lora_cfg.get("lora_lr")
+        lora_wd = lora_cfg.get("lora_weight_decay", 0.0)
+        if lora_lr is not None:
+            lora_params = {"params": [], "lr": lora_lr, "weight_decay": lora_wd}
+            for group in param_groups:
+                remaining = []
+                for p in group["params"]:
+                    if getattr(p, "_is_lora_param", False):
+                        lora_params["params"].append(p)
+                    else:
+                        remaining.append(p)
+                group["params"] = remaining
+            if lora_params["params"]:
+                param_groups.append(lora_params)
+
+    return param_groups
 
 
 def exists(x):
@@ -120,6 +140,29 @@ class Lambda(torch.nn.Module):
 
     def forward(self, x):
         return self.func(x)
+
+
+def _ensure_requires_grad(args):
+    """Enable requires_grad on the first floating-point tensor in *args*.
+
+    DeepSpeed's reentrant activation-checkpoint (CheckpointFunction.apply) only
+    attaches a grad_fn to its outputs when at least one input tensor has
+    requires_grad=True.  When the base model is frozen (e.g. LoRA), the hidden
+    states flowing out of the embedding layer have no grad_fn and therefore
+    requires_grad=False, which silently breaks the backward graph.
+
+    Calling this on the unpacked tuple of checkpoint inputs is sufficient —
+    autograd only needs *one* tensor to require grad for the whole
+    CheckpointFunction node to participate in the backward pass.
+    """
+    found = False
+    result = []
+    for a in args:
+        if not found and isinstance(a, torch.Tensor) and a.is_floating_point() and not a.requires_grad:
+            a = a.detach().requires_grad_(True)
+            found = True
+        result.append(a)
+    return tuple(result)
 
 
 class SequentialWrapper(torch.nn.Module):
@@ -211,6 +254,11 @@ class SequentialWrapper(torch.nn.Module):
                     x = (x,)
 
                 if self._is_checkpointable(funcs):
+                    # Ensure at least one input tensor requires grad for the
+                    # reentrant checkpoint to create a backward graph.  Without
+                    # this, frozen-base-model setups (e.g. LoRA) produce outputs
+                    # with no grad_fn and backward() fails.
+                    x = _ensure_requires_grad(x)
                     x = self.activation_checkpoint_func(exec_range_func(start_idx, end_idx), *x)
                 else:
                     x = exec_range_func(start_idx, end_idx)(*x)

--- a/savanna/training.py
+++ b/savanna/training.py
@@ -318,9 +318,9 @@ def update_data_loading_config(global_config):
     ckpt_dir = f"{global_config.load}/{tag}"
     # Rank 0 model states should always be saved.
     if global_config.zero_optimization["stage"] > 1:
-        state_dict = torch.load(f"{ckpt_dir}/zero_pp_rank_0_mp_rank_00_model_states.pt", map_location=torch.device("cpu"))
+        state_dict = torch.load(f"{ckpt_dir}/zero_pp_rank_0_mp_rank_00_model_states.pt", map_location=torch.device("cpu"), weights_only=False)
     else:
-        state_dict = torch.load(f"{ckpt_dir}/mp_rank_00_model_states.pt", map_location=torch.device("cpu"))
+        state_dict = torch.load(f"{ckpt_dir}/mp_rank_00_model_states.pt", map_location=torch.device("cpu"), weights_only=False)
 
     # Set previous data loading values.
     if "data_loading" in state_dict:
@@ -1032,6 +1032,23 @@ def get_model(global_config, use_cache=False):
             if "soft_embedding" not in name:
                 param.requires_grad = False
 
+    ### LoRA stuff ###
+    if global_config.lora is not None and global_config.lora.get("enabled", False):
+        from savanna.lora import apply_lora_to_model
+
+        apply_lora_to_model(model, global_config)
+        if global_config.lora.get("freeze_base_model", True):
+            modules_to_save = global_config.lora.get("modules_to_save") or []
+            for name, param in model.named_parameters():
+                # Use leaf-name matching (consistent with apply_lora_to_model) to
+                # avoid substring false positives (e.g. "norm" matching "layernorm").
+                leaf = name.rsplit(".", 1)[-1]
+                if "lora_" not in name and not any(m == leaf for m in modules_to_save):
+                    param.requires_grad = False
+        trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+        total = sum(p.numel() for p in model.parameters())
+        print_rank_0(f"LoRA: {trainable:,} trainable params / {total:,} total ({100 * trainable / total:.2f}%)")
+
     if not global_config.is_pipe_parallel:
         # Export PipeParallel model to nn.Sequential model to avoid the overhead of deepspeed's pipe parallel training
         model = model.to_sequential()
@@ -1365,7 +1382,7 @@ def setup_model_and_optimizer(global_config, use_cache=False, iteration=None):
     # jeromeku: We need to take into account the case where load is provided right at start of training
     # That is, we would like to provide the same save and load dir such that the same model config can be submitted 
     # to SLURM job again for job queuing and fault tolerance tools such as NVIDIA Heimdall.
-    should_load = global_config.load is not None and (iteration > 0 or global_config.warmstart)
+    should_load = global_config.load is not None and (iteration > 0 or global_config.warmstart or global_config.finetune)
     
     if should_load:
         global_config.iteration = load_checkpoint(

--- a/tests/unit/test_lora.py
+++ b/tests/unit/test_lora.py
@@ -1,0 +1,762 @@
+"""Unit tests for LoRA implementation."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.nn as nn
+
+from savanna.lora import (
+    LoRAColumnParallelLinear,
+    LoRARowParallelLinear,
+    LoRATELinear,
+    apply_lora_to_model,
+    get_lora_state_dict,
+    load_lora_state_dict,
+    merge_lora_weights,
+    unmerge_lora_weights,
+    _get_parent_and_attr,
+)
+from savanna.model.utils import _ensure_requires_grad
+
+
+# ---------------------------------------------------------------------------
+# Helpers: mock parallel linear layers that match the real interface
+# ---------------------------------------------------------------------------
+
+
+class MockColumnParallelLinear(nn.Module):
+    """Mimics ColumnParallelLinear for testing without distributed init."""
+
+    def __init__(self, input_size, output_size, tp_size=1):
+        super().__init__()
+        self.input_size = input_size
+        self.output_size = output_size
+        self.output_size_per_partition = output_size // tp_size
+        self.sequence_parallel = False
+        self.seq_dim = 0
+        self.weight = nn.Parameter(torch.randn(self.output_size_per_partition, input_size))
+        self.bias = nn.Parameter(torch.randn(self.output_size_per_partition))
+
+    def forward(self, input_):
+        output = nn.functional.linear(input_, self.weight, self.bias)
+        return output, None
+
+
+class MockRowParallelLinear(nn.Module):
+    """Mimics RowParallelLinear for testing without distributed init."""
+
+    def __init__(self, input_size, output_size, tp_size=1):
+        super().__init__()
+        self.input_size = input_size
+        self.output_size = output_size
+        self.input_size_per_partition = input_size // tp_size
+        self.input_is_parallel = True
+        self.sequence_parallel = False
+        self.parallel_output = False
+        self.seq_dim = 0
+        self.weight = nn.Parameter(torch.randn(output_size, self.input_size_per_partition))
+        self.bias = nn.Parameter(torch.randn(output_size))
+
+    def forward(self, input_):
+        output = nn.functional.linear(input_, self.weight, self.bias)
+        return output, None
+
+
+class MockTEConfig:
+    """Mimics TransformerEngine config for TELinear."""
+
+    def __init__(self, sequence_parallel=False, model_parallel_size=1, seq_dim=0):
+        self.sequence_parallel = sequence_parallel
+        self.model_parallel_size = model_parallel_size
+        self.seq_dim = seq_dim
+
+
+class MockTELinear(nn.Module):
+    """Mimics TELinear for testing without TransformerEngine or distributed init.
+
+    For column parallel: in_features is full, out_features is partitioned.
+    For row parallel: in_features is partitioned, out_features is full.
+    """
+
+    def __init__(self, in_features, out_features, config, parallel_mode="column"):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.config = config
+        self.parallel_mode = parallel_mode
+        self.weight = nn.Parameter(torch.randn(out_features, in_features))
+        self.bias = nn.Parameter(torch.randn(out_features))
+
+    def forward(self, input_):
+        output = nn.functional.linear(input_, self.weight, self.bias)
+        return output, None
+
+
+def _identity(x, **kwargs):
+    """No-op replacement for distributed comm functions in tests."""
+    return x
+
+
+# ---------------------------------------------------------------------------
+# Tests: LoRA layer shapes
+# ---------------------------------------------------------------------------
+
+
+class TestLoRAColumnParallelLinear:
+    def test_shapes(self):
+        base = MockColumnParallelLinear(64, 128)
+        lora = LoRAColumnParallelLinear(base, r=8, alpha=16.0)
+        assert lora.lora_A.shape == (8, 64)
+        assert lora.lora_B.shape == (128, 8)
+
+    def test_shapes_with_tp(self):
+        base = MockColumnParallelLinear(64, 128, tp_size=2)
+        lora = LoRAColumnParallelLinear(base, r=4, alpha=8.0)
+        # A is full input, B is partitioned
+        assert lora.lora_A.shape == (4, 64)
+        assert lora.lora_B.shape == (64, 4)  # 128 // 2 = 64
+
+    def test_zero_init_b(self):
+        base = MockColumnParallelLinear(64, 128)
+        lora = LoRAColumnParallelLinear(base, r=8, alpha=16.0)
+        assert torch.all(lora.lora_B == 0)
+
+    def test_forward_matches_base_when_b_is_zero(self):
+        base = MockColumnParallelLinear(32, 64)
+        lora = LoRAColumnParallelLinear(base, r=4, alpha=8.0)
+        x = torch.randn(2, 10, 32)
+        base_out, base_bias = base(x)
+        lora_out, lora_bias = lora(x)
+        torch.testing.assert_close(lora_out, base_out)
+
+    def test_forward_adds_lora_delta(self):
+        base = MockColumnParallelLinear(32, 64)
+        lora = LoRAColumnParallelLinear(base, r=4, alpha=8.0)
+        # Set B to non-zero
+        lora.lora_B.data.fill_(0.1)
+        x = torch.randn(2, 10, 32)
+        base_out, _ = base(x)
+        lora_out, _ = lora(x)
+        # Output should differ now
+        assert not torch.allclose(lora_out, base_out)
+
+    def test_scaling(self):
+        base = MockColumnParallelLinear(32, 64)
+        lora = LoRAColumnParallelLinear(base, r=4, alpha=16.0)
+        assert lora.scaling == 16.0 / 4
+
+    def test_is_lora_param_attribute(self):
+        base = MockColumnParallelLinear(32, 64)
+        lora = LoRAColumnParallelLinear(base, r=4, alpha=8.0)
+        assert lora.lora_A._is_lora_param is True
+        assert lora.lora_B._is_lora_param is True
+
+
+class TestLoRARowParallelLinear:
+    def test_shapes(self):
+        base = MockRowParallelLinear(64, 128)
+        lora = LoRARowParallelLinear(base, r=8, alpha=16.0)
+        assert lora.lora_A.shape == (8, 64)
+        assert lora.lora_B.shape == (128, 8)
+
+    def test_shapes_with_tp(self):
+        base = MockRowParallelLinear(128, 64, tp_size=2)
+        lora = LoRARowParallelLinear(base, r=4, alpha=8.0)
+        # A is partitioned (input_size_per_partition), B is full
+        assert lora.lora_A.shape == (4, 64)  # 128 // 2 = 64
+        assert lora.lora_B.shape == (64, 4)
+
+    def test_zero_init_b(self):
+        base = MockRowParallelLinear(64, 128)
+        lora = LoRARowParallelLinear(base, r=8, alpha=16.0)
+        assert torch.all(lora.lora_B == 0)
+
+    @patch("savanna.lora.reduce_from_model_parallel_region", side_effect=_identity)
+    def test_forward_matches_base_when_b_is_zero(self, mock_reduce):
+        base = MockRowParallelLinear(32, 64)
+        lora = LoRARowParallelLinear(base, r=4, alpha=8.0)
+        x = torch.randn(2, 10, 32)
+        base_out, base_bias = base(x)
+        lora_out, lora_bias = lora(x)
+        torch.testing.assert_close(lora_out, base_out)
+
+
+# ---------------------------------------------------------------------------
+# Tests: merge/unmerge
+# ---------------------------------------------------------------------------
+
+
+class TestMergeUnmerge:
+    def _make_model_with_lora(self):
+        model = nn.Module()
+        base = MockColumnParallelLinear(32, 64)
+        lora = LoRAColumnParallelLinear(base, r=4, alpha=8.0)
+        # Set non-zero LoRA weights
+        lora.lora_A.data.normal_()
+        lora.lora_B.data.normal_()
+        model.layer = lora
+        return model
+
+    def test_merge_changes_base_weight(self):
+        model = self._make_model_with_lora()
+        original_weight = model.layer.base_layer.weight.data.clone()
+        merge_lora_weights(model)
+        assert not torch.allclose(model.layer.base_layer.weight.data, original_weight)
+
+    def test_unmerge_restores_base_weight(self):
+        model = self._make_model_with_lora()
+        original_weight = model.layer.base_layer.weight.data.clone()
+        merge_lora_weights(model)
+        unmerge_lora_weights(model)
+        torch.testing.assert_close(model.layer.base_layer.weight.data, original_weight)
+
+    def test_double_merge_is_noop(self):
+        model = self._make_model_with_lora()
+        merge_lora_weights(model)
+        weight_after_first_merge = model.layer.base_layer.weight.data.clone()
+        merge_lora_weights(model)  # should be a no-op
+        torch.testing.assert_close(model.layer.base_layer.weight.data, weight_after_first_merge)
+
+    def test_merge_flag(self):
+        model = self._make_model_with_lora()
+        assert not getattr(model.layer, "_lora_merged", False)
+        merge_lora_weights(model)
+        assert model.layer._lora_merged is True
+        unmerge_lora_weights(model)
+        assert model.layer._lora_merged is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: state dict helpers
+# ---------------------------------------------------------------------------
+
+
+class TestStateDictHelpers:
+    def test_get_lora_state_dict(self):
+        model = nn.Module()
+        base = MockColumnParallelLinear(32, 64)
+        lora = LoRAColumnParallelLinear(base, r=4, alpha=8.0)
+        model.layer = lora
+        sd = get_lora_state_dict(model)
+        assert "layer.lora_A" in sd
+        assert "layer.lora_B" in sd
+        # Should NOT contain base layer weights
+        assert not any("base_layer" in k and "lora_" not in k for k in sd)
+
+    def test_load_lora_state_dict(self):
+        model = nn.Module()
+        base = MockColumnParallelLinear(32, 64)
+        lora = LoRAColumnParallelLinear(base, r=4, alpha=8.0)
+        model.layer = lora
+
+        # Save the original lora_A
+        original_A = model.layer.lora_A.data.clone()
+        sd = get_lora_state_dict(model)
+        # Modify the params in the model
+        model.layer.lora_A.data.fill_(42.0)
+        assert torch.all(model.layer.lora_A.data == 42.0)
+        # Reload from saved state dict
+        load_lora_state_dict(model, sd)
+        # Should be restored to original
+        torch.testing.assert_close(model.layer.lora_A.data, original_A)
+
+
+# ---------------------------------------------------------------------------
+# Tests: apply_lora_to_model
+# ---------------------------------------------------------------------------
+
+
+class TestApplyLoRA:
+    def _make_model_and_config(self, target_modules):
+        model = nn.Module()
+        model.dense_projection = MockColumnParallelLinear(32, 64)
+        model.dense = MockRowParallelLinear(64, 32)
+        model.layernorm = nn.LayerNorm(32)
+
+        global_config = MagicMock()
+        global_config.lora = {
+            "enabled": True,
+            "r": 4,
+            "alpha": 8.0,
+            "dropout": 0.0,
+            "target_modules": target_modules,
+        }
+        return model, global_config
+
+    @patch("savanna.lora.print_rank_0")
+    @patch("savanna.mpu.layers.ColumnParallelLinear", MockColumnParallelLinear)
+    @patch("savanna.mpu.layers.RowParallelLinear", MockRowParallelLinear)
+    def test_wraps_target_modules(self, mock_print):
+        model, config = self._make_model_and_config(["dense_projection", "dense"])
+        apply_lora_to_model(model, config)
+        assert isinstance(model.dense_projection, LoRAColumnParallelLinear)
+        assert isinstance(model.dense, LoRARowParallelLinear)
+
+    @patch("savanna.lora.print_rank_0")
+    @patch("savanna.mpu.layers.ColumnParallelLinear", MockColumnParallelLinear)
+    @patch("savanna.mpu.layers.RowParallelLinear", MockRowParallelLinear)
+    def test_does_not_wrap_non_targets(self, mock_print):
+        model, config = self._make_model_and_config(["dense_projection"])
+        apply_lora_to_model(model, config)
+        assert isinstance(model.dense_projection, LoRAColumnParallelLinear)
+        assert isinstance(model.dense, MockRowParallelLinear)  # not wrapped
+        assert isinstance(model.layernorm, nn.LayerNorm)  # not wrapped
+
+    @patch("savanna.lora.print_rank_0")
+    @patch("savanna.mpu.layers.ColumnParallelLinear", MockColumnParallelLinear)
+    @patch("savanna.mpu.layers.RowParallelLinear", MockRowParallelLinear)
+    def test_base_layer_preserved(self, mock_print):
+        model, config = self._make_model_and_config(["dense_projection"])
+        original_weight = model.dense_projection.weight.data.clone()
+        apply_lora_to_model(model, config)
+        torch.testing.assert_close(model.dense_projection.base_layer.weight.data, original_weight)
+
+    @patch("savanna.lora.print_rank_0")
+    @patch("savanna.mpu.layers.ColumnParallelLinear", MockColumnParallelLinear)
+    @patch("savanna.mpu.layers.RowParallelLinear", MockRowParallelLinear)
+    def test_nested_modules(self, mock_print):
+        model = nn.Module()
+        block = nn.Module()
+        block.dense_projection = MockColumnParallelLinear(32, 64)
+        block.dense = MockRowParallelLinear(64, 32)
+        model.block = block
+
+        config = MagicMock()
+        config.lora = {
+            "enabled": True,
+            "r": 4,
+            "alpha": 8.0,
+            "dropout": 0.0,
+            "target_modules": ["dense_projection", "dense"],
+        }
+        apply_lora_to_model(model, config)
+        assert isinstance(model.block.dense_projection, LoRAColumnParallelLinear)
+        assert isinstance(model.block.dense, LoRARowParallelLinear)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _get_parent_and_attr helper
+# ---------------------------------------------------------------------------
+
+
+class TestGetParentAndAttr:
+    def test_simple_name(self):
+        model = nn.Module()
+        model.layer = nn.Linear(10, 10)
+        parent, attr = _get_parent_and_attr(model, "layer")
+        assert parent is model
+        assert attr == "layer"
+
+    def test_dotted_name(self):
+        model = nn.Module()
+        model.block = nn.Module()
+        model.block.layer = nn.Linear(10, 10)
+        parent, attr = _get_parent_and_attr(model, "block.layer")
+        assert parent is model.block
+        assert attr == "layer"
+
+
+# ---------------------------------------------------------------------------
+# Tests: config parsing
+# ---------------------------------------------------------------------------
+
+
+class TestLoRAConfig:
+    def test_config_defaults(self):
+        from savanna.arguments.lora_config import GlobalConfigLoRA
+
+        config = GlobalConfigLoRA()
+        assert config.lora is None
+
+    def test_config_from_dict(self):
+        from savanna.arguments.lora_config import GlobalConfigLoRA
+
+        config = GlobalConfigLoRA(
+            lora={
+                "enabled": True,
+                "r": 16,
+                "alpha": 32.0,
+                "target_modules": ["dense"],
+            }
+        )
+        assert config.lora["enabled"] is True
+        assert config.lora["r"] == 16
+        assert config.lora["alpha"] == 32.0
+        assert config.lora["target_modules"] == ["dense"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: dropout
+# ---------------------------------------------------------------------------
+
+
+class TestDropout:
+    def test_no_dropout(self):
+        base = MockColumnParallelLinear(32, 64)
+        lora = LoRAColumnParallelLinear(base, r=4, alpha=8.0, dropout=0.0)
+        assert isinstance(lora.lora_dropout, nn.Identity)
+
+    def test_with_dropout(self):
+        base = MockColumnParallelLinear(32, 64)
+        lora = LoRAColumnParallelLinear(base, r=4, alpha=8.0, dropout=0.1)
+        assert isinstance(lora.lora_dropout, nn.Dropout)
+
+
+# ---------------------------------------------------------------------------
+# Tests: integration - forward/backward pass
+# ---------------------------------------------------------------------------
+
+
+class TestIntegration:
+    def test_backward_pass(self):
+        base = MockColumnParallelLinear(32, 64)
+        lora = LoRAColumnParallelLinear(base, r=4, alpha=8.0)
+        lora.lora_B.data.fill_(0.1)
+
+        x = torch.randn(2, 10, 32, requires_grad=True)
+        out, _ = lora(x)
+        loss = out.sum()
+        loss.backward()
+
+        assert lora.lora_A.grad is not None
+        assert lora.lora_B.grad is not None
+
+    def test_only_lora_params_require_grad_after_freeze(self):
+        model = nn.Module()
+        model.dense = MockColumnParallelLinear(32, 64)
+
+        # Wrap with LoRA
+        lora = LoRAColumnParallelLinear(model.dense, r=4, alpha=8.0)
+        model.dense = lora
+
+        # Freeze base
+        for name, param in model.named_parameters():
+            if "lora_" not in name:
+                param.requires_grad = False
+
+        trainable = [n for n, p in model.named_parameters() if p.requires_grad]
+        assert "dense.lora_A" in trainable
+        assert "dense.lora_B" in trainable
+        assert all("lora_" in n for n in trainable)
+
+
+# ---------------------------------------------------------------------------
+# Tests: LoRATELinear
+# ---------------------------------------------------------------------------
+
+
+class TestLoRATELinear:
+    def test_column_shapes_tp1(self):
+        config = MockTEConfig(model_parallel_size=1)
+        base = MockTELinear(64, 128, config, parallel_mode="column")
+        lora = LoRATELinear(base, r=8, alpha=16.0, parallel_mode="column")
+        # A: full input, B: partitioned output (= out_features with TP=1)
+        assert lora.lora_A.shape == (8, 64)
+        assert lora.lora_B.shape == (128, 8)
+
+    def test_column_shapes_tp2(self):
+        config = MockTEConfig(model_parallel_size=2)
+        # With TP=2 column: TE stores out_features = full / tp_size
+        base = MockTELinear(64, 64, config, parallel_mode="column")  # 128/2 = 64 out
+        lora = LoRATELinear(base, r=4, alpha=8.0, parallel_mode="column")
+        assert lora.lora_A.shape == (4, 64)  # full input
+        assert lora.lora_B.shape == (64, 4)  # partitioned output
+
+    def test_row_shapes_tp1(self):
+        config = MockTEConfig(model_parallel_size=1)
+        base = MockTELinear(64, 128, config, parallel_mode="row")
+        lora = LoRATELinear(base, r=8, alpha=16.0, parallel_mode="row")
+        # A: partitioned input (= in_features with TP=1), B: full output
+        assert lora.lora_A.shape == (8, 64)
+        assert lora.lora_B.shape == (128, 8)
+
+    def test_row_shapes_tp2(self):
+        config = MockTEConfig(model_parallel_size=2)
+        # With TP=2 row: TE stores in_features = full / tp_size, out_features = full
+        base = MockTELinear(32, 128, config, parallel_mode="row")  # 64/2 = 32 in
+        lora = LoRATELinear(base, r=4, alpha=8.0, parallel_mode="row")
+        assert lora.lora_A.shape == (4, 32)  # partitioned input
+        assert lora.lora_B.shape == (128, 4)  # full output
+
+    def test_zero_init_b(self):
+        config = MockTEConfig()
+        base = MockTELinear(64, 128, config)
+        lora = LoRATELinear(base, r=8, alpha=16.0, parallel_mode="column")
+        assert torch.all(lora.lora_B == 0)
+
+    def test_lora_params_are_bf16(self):
+        config = MockTEConfig()
+        base = MockTELinear(64, 128, config)
+        lora = LoRATELinear(base, r=8, alpha=16.0, parallel_mode="column")
+        assert lora.lora_A.dtype == torch.bfloat16
+        assert lora.lora_B.dtype == torch.bfloat16
+
+    @patch("savanna.lora.reduce_from_model_parallel_region", side_effect=_identity)
+    def test_column_forward_matches_base_when_b_is_zero(self, mock_reduce):
+        config = MockTEConfig()
+        base = MockTELinear(32, 64, config)
+        lora = LoRATELinear(base, r=4, alpha=8.0, parallel_mode="column")
+        x = torch.randn(2, 10, 32)
+        base_out, _ = base(x)
+        lora_out, _ = lora(x)
+        torch.testing.assert_close(lora_out, base_out)
+
+    @patch("savanna.lora.reduce_from_model_parallel_region", side_effect=_identity)
+    def test_row_forward_matches_base_when_b_is_zero(self, mock_reduce):
+        config = MockTEConfig()
+        base = MockTELinear(32, 64, config)
+        lora = LoRATELinear(base, r=4, alpha=8.0, parallel_mode="row")
+        x = torch.randn(2, 10, 32)
+        base_out, _ = base(x)
+        lora_out, _ = lora(x)
+        torch.testing.assert_close(lora_out, base_out)
+
+    @patch("savanna.lora.reduce_from_model_parallel_region", side_effect=_identity)
+    def test_column_forward_adds_lora_delta(self, mock_reduce):
+        config = MockTEConfig()
+        base = MockTELinear(32, 64, config)
+        lora = LoRATELinear(base, r=4, alpha=8.0, parallel_mode="column")
+        lora.lora_B.data.fill_(0.1)
+        x = torch.randn(2, 10, 32)
+        base_out, _ = base(x)
+        lora_out, _ = lora(x)
+        assert not torch.allclose(lora_out, base_out)
+
+    @patch("savanna.lora.reduce_from_model_parallel_region", side_effect=_identity)
+    def test_row_forward_adds_lora_delta(self, mock_reduce):
+        config = MockTEConfig()
+        base = MockTELinear(32, 64, config)
+        lora = LoRATELinear(base, r=4, alpha=8.0, parallel_mode="row")
+        lora.lora_B.data.fill_(0.1)
+        x = torch.randn(2, 10, 32)
+        base_out, _ = base(x)
+        lora_out, _ = lora(x)
+        assert not torch.allclose(lora_out, base_out)
+
+    @patch("savanna.lora.reduce_from_model_parallel_region", side_effect=_identity)
+    def test_backward_pass_column(self, mock_reduce):
+        config = MockTEConfig()
+        base = MockTELinear(32, 64, config)
+        lora = LoRATELinear(base, r=4, alpha=8.0, parallel_mode="column")
+        lora.lora_B.data.fill_(0.1)
+        x = torch.randn(2, 10, 32, requires_grad=True)
+        out, _ = lora(x)
+        loss = out.sum()
+        loss.backward()
+        assert lora.lora_A.grad is not None
+        assert lora.lora_B.grad is not None
+
+    @patch("savanna.lora.reduce_from_model_parallel_region", side_effect=_identity)
+    def test_backward_pass_row(self, mock_reduce):
+        config = MockTEConfig()
+        base = MockTELinear(32, 64, config)
+        lora = LoRATELinear(base, r=4, alpha=8.0, parallel_mode="row")
+        lora.lora_B.data.fill_(0.1)
+        x = torch.randn(2, 10, 32, requires_grad=True)
+        out, _ = lora(x)
+        loss = out.sum()
+        loss.backward()
+        assert lora.lora_A.grad is not None
+        assert lora.lora_B.grad is not None
+
+    def test_is_lora_param_attribute(self):
+        config = MockTEConfig()
+        base = MockTELinear(32, 64, config)
+        lora = LoRATELinear(base, r=4, alpha=8.0, parallel_mode="column")
+        assert lora.lora_A._is_lora_param is True
+        assert lora.lora_B._is_lora_param is True
+
+    def test_invalid_parallel_mode_raises(self):
+        config = MockTEConfig()
+        base = MockTELinear(32, 64, config)
+        with pytest.raises(ValueError, match="Cannot determine parallel_mode"):
+            LoRATELinear(base, r=4, alpha=8.0, parallel_mode=None)
+
+    def test_seq_dim_from_config(self):
+        config = MockTEConfig(seq_dim=1)
+        base = MockTELinear(32, 64, config)
+        lora = LoRATELinear(base, r=4, alpha=8.0, parallel_mode="column")
+        assert lora.seq_dim == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: LoRARowParallelLinear additional tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoRARowParallelLinearExtended:
+    @patch("savanna.lora.reduce_from_model_parallel_region", side_effect=_identity)
+    def test_backward_pass(self, mock_reduce):
+        base = MockRowParallelLinear(32, 64)
+        lora = LoRARowParallelLinear(base, r=4, alpha=8.0)
+        lora.lora_B.data.fill_(0.1)
+        x = torch.randn(2, 10, 32, requires_grad=True)
+        out, _ = lora(x)
+        loss = out.sum()
+        loss.backward()
+        assert lora.lora_A.grad is not None
+        assert lora.lora_B.grad is not None
+
+    @patch("savanna.lora.reduce_from_model_parallel_region", side_effect=_identity)
+    def test_forward_adds_lora_delta(self, mock_reduce):
+        base = MockRowParallelLinear(32, 64)
+        lora = LoRARowParallelLinear(base, r=4, alpha=8.0)
+        lora.lora_B.data.fill_(0.1)
+        x = torch.randn(2, 10, 32)
+        base_out, _ = base(x)
+        lora_out, _ = lora(x)
+        assert not torch.allclose(lora_out, base_out)
+
+    def test_parallel_output_warning(self):
+        """parallel_output=True with TP > 1 should emit a warning."""
+        base = MockRowParallelLinear(128, 64, tp_size=2)
+        base.parallel_output = True
+        with patch("savanna.lora.logger") as mock_logger:
+            LoRARowParallelLinear(base, r=4, alpha=8.0)
+            mock_logger.warning.assert_called_once()
+            assert "parallel_output=True" in mock_logger.warning.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Tests: _ensure_requires_grad
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureRequiresGrad:
+    def test_enables_grad_on_first_float_tensor(self):
+        t = torch.randn(4, 4)
+        assert not t.requires_grad
+        result = _ensure_requires_grad((t,))
+        assert result[0].requires_grad
+
+    def test_only_enables_first_tensor(self):
+        t1 = torch.randn(4)
+        t2 = torch.randn(4)
+        result = _ensure_requires_grad((t1, t2))
+        assert result[0].requires_grad
+        assert not result[1].requires_grad
+
+    def test_skips_non_float_tensors(self):
+        int_t = torch.tensor([1, 2, 3])
+        float_t = torch.randn(4)
+        result = _ensure_requires_grad((int_t, float_t))
+        assert not result[0].requires_grad  # int tensor skipped
+        assert result[1].requires_grad  # first float tensor gets grad
+
+    def test_noop_if_already_requires_grad(self):
+        t = torch.randn(4, requires_grad=True)
+        result = _ensure_requires_grad((t,))
+        assert result[0] is t  # same object, not detached
+
+    def test_noop_for_non_tensor_args(self):
+        result = _ensure_requires_grad((None, "string", 42))
+        assert result == (None, "string", 42)
+
+    def test_mixed_args(self):
+        non_tensor = "hello"
+        int_t = torch.tensor([1, 2])
+        float_t = torch.randn(3)
+        result = _ensure_requires_grad((non_tensor, int_t, float_t))
+        assert result[0] == "hello"
+        assert not result[1].requires_grad
+        assert result[2].requires_grad
+
+
+# ---------------------------------------------------------------------------
+# Tests: config validation
+# ---------------------------------------------------------------------------
+
+
+class TestLoRAConfigValidation:
+    def test_r_zero_raises(self):
+        from savanna.arguments.lora_config import GlobalConfigLoRA
+
+        with pytest.raises(ValueError, match="positive integer"):
+            GlobalConfigLoRA(lora={"enabled": True, "r": 0, "target_modules": ["dense"]})
+
+    def test_r_float_raises(self):
+        from savanna.arguments.lora_config import GlobalConfigLoRA
+
+        with pytest.raises(ValueError, match="positive integer"):
+            GlobalConfigLoRA(lora={"enabled": True, "r": 8.5, "target_modules": ["dense"]})
+
+    def test_r_negative_raises(self):
+        from savanna.arguments.lora_config import GlobalConfigLoRA
+
+        with pytest.raises(ValueError, match="positive integer"):
+            GlobalConfigLoRA(lora={"enabled": True, "r": -1, "target_modules": ["dense"]})
+
+    def test_alpha_zero_raises(self):
+        from savanna.arguments.lora_config import GlobalConfigLoRA
+
+        with pytest.raises(ValueError, match="positive number"):
+            GlobalConfigLoRA(lora={"enabled": True, "r": 8, "alpha": 0, "target_modules": ["dense"]})
+
+    def test_alpha_negative_raises(self):
+        from savanna.arguments.lora_config import GlobalConfigLoRA
+
+        with pytest.raises(ValueError, match="positive number"):
+            GlobalConfigLoRA(lora={"enabled": True, "r": 8, "alpha": -1.0, "target_modules": ["dense"]})
+
+    def test_dropout_out_of_range_raises(self):
+        from savanna.arguments.lora_config import GlobalConfigLoRA
+
+        with pytest.raises(ValueError, match="dropout"):
+            GlobalConfigLoRA(
+                lora={"enabled": True, "r": 8, "dropout": 1.0, "target_modules": ["dense"]}
+            )
+
+    def test_dropout_negative_raises(self):
+        from savanna.arguments.lora_config import GlobalConfigLoRA
+
+        with pytest.raises(ValueError, match="dropout"):
+            GlobalConfigLoRA(
+                lora={"enabled": True, "r": 8, "dropout": -0.1, "target_modules": ["dense"]}
+            )
+
+    def test_target_modules_string_raises(self):
+        from savanna.arguments.lora_config import GlobalConfigLoRA
+
+        with pytest.raises(ValueError, match="list of strings"):
+            GlobalConfigLoRA(lora={"enabled": True, "r": 8, "target_modules": "dense"})
+
+    def test_valid_config_passes(self):
+        from savanna.arguments.lora_config import GlobalConfigLoRA
+
+        config = GlobalConfigLoRA(
+            lora={"enabled": True, "r": 8, "alpha": 16.0, "dropout": 0.1, "target_modules": ["dense"]}
+        )
+        assert config.lora["r"] == 8
+
+    def test_disabled_config_skips_validation(self):
+        from savanna.arguments.lora_config import GlobalConfigLoRA
+
+        # Should not raise even with bad r, because enabled=False
+        config = GlobalConfigLoRA(lora={"enabled": False, "r": 0})
+        assert config.lora["r"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: unmerge numerical stability (bf16)
+# ---------------------------------------------------------------------------
+
+
+class TestUnmergeStability:
+    def test_unmerge_exact_in_bf16(self):
+        """Verify unmerge restores the exact original weight in bf16."""
+        base = MockColumnParallelLinear(32, 64)
+        base.weight.data = base.weight.data.to(torch.bfloat16)
+        lora = LoRAColumnParallelLinear(base, r=4, alpha=8.0)
+        lora.lora_A.data = lora.lora_A.data.to(torch.bfloat16)
+        lora.lora_B.data.normal_()
+        lora.lora_B.data = lora.lora_B.data.to(torch.bfloat16)
+
+        model = nn.Module()
+        model.layer = lora
+
+        original_weight = base.weight.data.clone()
+        merge_lora_weights(model)
+        unmerge_lora_weights(model)
+        # Should be bit-exact since we restore from saved original
+        assert torch.equal(base.weight.data, original_weight)


### PR DESCRIPTION
## Summary

Add LoRA (Low-Rank Adaptation) support to Savanna, enabling parameter-efficient finetuning of StripedHyena/Evo models by training low-rank adapter matrices while keeping the base model frozen.

- Wraps `ColumnParallelLinear`, `RowParallelLinear`, and `TELinear` (FP8) with LoRA adapters
- YAML-configurable: rank, alpha, dropout, target modules, separate LR, freeze control
- Save/load LoRA weights separately per MP rank, or merged into base weights
- Checkpoint key remapping for loading base checkpoints into LoRA-wrapped models
- Compatible with activation checkpointing (`_ensure_requires_grad` fix for frozen base + reentrant checkpoint)
- Config validation catches common misconfigurations (bad rank, float rank, string target_modules)

## PRD

### Goal
Enable parameter-efficient finetuning of Savanna models by adding LoRA adapters to configurable linear layers, while keeping the base model frozen.

### Supported layer types
| Layer | LoRA wrapper | Notes |
|---|---|---|
| `ColumnParallelLinear` | `LoRAColumnParallelLinear` | A: full input, B: partitioned output |
| `RowParallelLinear` | `LoRARowParallelLinear` | A: partitioned input, B: full output |
| `TELinear` (FP8) | `LoRATELinear` | bf16 LoRA params on top of FP8 base |

### Configuration
```yaml
lora:
  enabled: true
  r: 16                    # rank
  alpha: 32.0              # scaling = alpha / r
  dropout: 0.05
  target_modules:          # leaf module names to wrap
    - "dense_projection"   # QKV (ColumnParallel)
    - "dense"              # output proj (RowParallel)
    - "w1"                 # GLU gate (ColumnParallel)
    - "w2"                 # GLU up-proj (ColumnParallel)
    - "w3"                 # GLU down-proj (RowParallel)
  freeze_base_model: true
  modules_to_save: []      # additional modules to keep trainable
  save_merged: false       # merge LoRA into base on save
  lora_lr: 0.0003          # separate LR for LoRA params
  lora_weight_decay: 0.0
```

### Key design decisions
- **LoRA params in bf16** even when base uses FP8 — avoids quantization noise in low-rank adapters
- **Checkpoint key remapping** (`_make_lora_custom_load_fn`) — transparently loads base checkpoints into LoRA-wrapped models by inserting `base_layer.` prefix
- **`_ensure_requires_grad`** — fixes interaction between frozen base model and DeepSpeed's reentrant activation checkpointing, which requires at least one input tensor with `requires_grad=True`
- **Merge/unmerge** saves original weight for exact restoration (avoids bf16 precision loss from add-then-subtract)
- **Async save guard** — forces blocking save when `save_merged=True` to prevent race condition with unmerge

### Out of scope
- Pipeline parallelism with LoRA
- QLoRA / quantized base weights
- LoRA for non-linear layers (embeddings, norms)

## Files changed

| File | Change |
|---|---|
| `savanna/lora.py` | **New.** LoRA wrapper classes, apply/merge/unmerge, state dict helpers |
| `savanna/arguments/lora_config.py` | **New.** `GlobalConfigLoRA` dataclass with validation |
| `tests/unit/test_lora.py` | **New.** 64 unit tests |
| `savanna/arguments/arguments.py` | Register `GlobalConfigLoRA` in `BASE_CLASSES` |
| `savanna/checkpointing.py` | LoRA save/load, key remapping, async save race fix |
| `savanna/model/utils.py` | LoRA param groups, `_ensure_requires_grad` for activation ckpt |
| `savanna/training.py` | Inject LoRA in `get_model()`, freeze base, finetune load path |

## Test plan

- [x] 64 unit tests covering all three wrapper classes, merge/unmerge, state dict, config validation, `_ensure_requires_grad`, backward passes
- [x] Lint clean (`ruff check` passes on all changed files)
- [x] Smoke tested: single-GPU LoRA finetuning of Evo2-7B with FP8/TELinear, loss decreasing, 30% MFU